### PR TITLE
Create man page directory if needed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ kr: $(sources)
 install: kr kr.1
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	install -m 755 kr $(DESTDIR)$(PREFIX)/bin
+	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
 	gzip < kr.1 > $(DESTDIR)$(PREFIX)/share/man/man1/kr.1.gz
 
 uninstall:


### PR DESCRIPTION
I didn't already have the /usr/local/share/man/man1 directory on my system, so I added a mkdir -p command to Makefile to create it if necessary.